### PR TITLE
Do not derive MIME type from image reference URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ isVertical | OK | OK | Will be true if the image is vertically oriented
 width | OK | OK | Image dimensions
 height | OK | OK | Image dimensions
 fileSize | OK | OK | The file size (photos only)
-type | - | OK | The file type (photos only)
+type | OK | OK | The file type (photos only)
 fileName | OK (photos and videos) | OK (photos) | The file name
 path | - | OK | The file path
 latitude | OK | OK | Latitude metadata, if available

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -363,9 +363,13 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
             NSData *data;
             if ([[[self.options objectForKey:@"imageFileType"] stringValue] isEqualToString:@"png"]) {
                 data = UIImagePNGRepresentation(image);
+                NSString *mimeType = (__bridge_transfer NSString *)(UTTypeCopyPreferredTagWithClass(kUTTypePNG, kUTTagClassMIMEType));
+                [self.response setObject:mimeType forKey:@"type"];
             }
             else {
                 data = UIImageJPEGRepresentation(image, [[self.options valueForKey:@"quality"] floatValue]);
+                NSString *mimeType = (__bridge_transfer NSString *)(UTTypeCopyPreferredTagWithClass(kUTTypeJPEG, kUTTagClassMIMEType));
+                [self.response setObject:mimeType forKey:@"type"];
             }
             [data writeToFile:path atomically:YES];
 
@@ -489,9 +493,6 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
                 }];
             }
         }
-
-        NSString *mimeType = [self mimeTypeForResourceAtURL:imageURL];
-        [self.response setObject:mimeType forKey:@"type"];
 
         // If storage options are provided, check the skipBackup flag
         if ([self.options objectForKey:@"storageOptions"] && [[self.options objectForKey:@"storageOptions"] isKindOfClass:[NSDictionary class]]) {
@@ -687,15 +688,6 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         NSLog(@"Error setting skip backup attribute: file not found");
         return @NO;
     }
-}
-
-- (NSString *)mimeTypeForResourceAtURL:(NSURL *)url
-{
-    NSString *filenameExtension = url.pathExtension;
-    CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)filenameExtension, nil);
-    NSString *mimeType = (__bridge_transfer NSString *)(UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType));
-    CFRelease(uti);
-    return mimeType;
 }
 
 #pragma mark - Class Methods


### PR DESCRIPTION
I discovered that UIImagePickerControllerReferenceURL was not a good source to derive the picked media item's MIME type from, because UIImagePickerControllerReferenceURL will be nil for for newly captured images. I also discovered that react-native-image-picker always creates either a PNG or JPEG representation of picked still images, so I decided to just set the MIME types on the response object for these data presentations when they are created.
