### PR TITLE
Add support for a custom path storage option on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ allowsEditing | OK | - | bool - enables built in iOS functionality to resize the
 noData | OK | OK | If true, disables the base64 `data` field from being generated (greatly improves performance on large photos)
 storageOptions | OK | OK | If this key is provided, the image will be saved in your app's `Documents` directory on iOS, or your app's `Pictures` directory on Android (rather than a temporary directory)
 storageOptions.skipBackup | OK | - | If true, the photo will NOT be backed up to iCloud
-storageOptions.path | OK | - | If set, will save the image at `Documents/[path]/` rather than the root `Documents`
+storageOptions.path | OK | OK | If set, it will save the image at `Documents/[path]/` rather than the root `Documents` on iOS or `Pictures/[path]/` on Android.
 storageOptions.cameraRoll | OK | OK | If true, the cropped photo will be saved to the iOS Camera Roll or Android DCIM folder.
 storageOptions.waitUntilSaved | OK | - | If true, will delay the response callback until after the photo/video was saved to the Camera Roll. If the photo or video was just taken, then the file name and timestamp fields are only provided in the response object when this AND `cameraRoll` are both true.
 permissionDenied.title | - | OK | Title of explaining permissions dialog. By default `Permission denied`.

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -74,7 +74,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
   protected Uri cameraCaptureURI;
   private Boolean noData = false;
   private Boolean pickVideo = false;
-  private ImageConfig imageConfig = new ImageConfig(null, null, 0, 0, 100, 0, false);
+  private ImageConfig imageConfig = new ImageConfig(null, null, 0, 0, 100, 0, false, null);
 
   @Deprecated
   private int videoQuality = 1;
@@ -149,7 +149,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
     this.callback = callback;
     this.options = options;
-    imageConfig = new ImageConfig(null, null, 0, 0, 100, 0, false);
+    imageConfig = new ImageConfig(null, null, 0, 0, 100, 0, false, null);
 
     final AlertDialog dialog = UI.chooseDialog(this, options, new UI.OnAction()
     {

--- a/android/src/main/java/com/imagepicker/media/ImageConfig.java
+++ b/android/src/main/java/com/imagepicker/media/ImageConfig.java
@@ -20,6 +20,7 @@ public class ImageConfig
     public final int quality;
     public final int rotation;
     public final boolean saveToCameraRoll;
+    public final String path;
 
     public ImageConfig(@Nullable final File original,
                        @Nullable final File resized,
@@ -27,7 +28,8 @@ public class ImageConfig
                        final int maxHeight,
                        final int quality,
                        final int rotation,
-                       final boolean saveToCameraRoll)
+                       final boolean saveToCameraRoll,
+                       final String path)
     {
         this.original = original;
         this.resized = resized;
@@ -36,6 +38,7 @@ public class ImageConfig
         this.quality = quality;
         this.rotation = rotation;
         this.saveToCameraRoll = saveToCameraRoll;
+        this.path = path;
     }
 
     public @NonNull ImageConfig withMaxWidth(final int maxWidth)
@@ -43,7 +46,7 @@ public class ImageConfig
         return new ImageConfig(
                 this.original, this.resized, maxWidth,
                 this.maxHeight, this.quality, this.rotation,
-                this.saveToCameraRoll
+                this.saveToCameraRoll, this.path
         );
     }
 
@@ -52,7 +55,7 @@ public class ImageConfig
         return new ImageConfig(
                 this.original, this.resized, this.maxWidth,
                 maxHeight, this.quality, this.rotation,
-                this.saveToCameraRoll
+                this.saveToCameraRoll, this.path
         );
 
     }
@@ -62,7 +65,7 @@ public class ImageConfig
         return new ImageConfig(
                 this.original, this.resized, this.maxWidth,
                 this.maxHeight, quality, this.rotation,
-                this.saveToCameraRoll
+                this.saveToCameraRoll, this.path
         );
     }
 
@@ -71,7 +74,7 @@ public class ImageConfig
         return new ImageConfig(
                 this.original, this.resized, this.maxWidth,
                 this.maxHeight, this.quality, rotation,
-                this.saveToCameraRoll
+                this.saveToCameraRoll, this.path
         );
     }
 
@@ -80,7 +83,7 @@ public class ImageConfig
         return new ImageConfig(
                 original, this.resized, this.maxWidth,
                 this.maxHeight, this.quality, this.rotation,
-                this.saveToCameraRoll
+                this.saveToCameraRoll, this.path
         );
     }
 
@@ -89,7 +92,7 @@ public class ImageConfig
         return new ImageConfig(
                 this.original, resized, this.maxWidth,
                 this.maxHeight, this.quality, this.rotation,
-                this.saveToCameraRoll
+                this.saveToCameraRoll, this.path
         );
     }
 
@@ -98,7 +101,16 @@ public class ImageConfig
         return new ImageConfig(
                 this.original, this.resized, this.maxWidth,
                 this.maxHeight, this.quality, this.rotation,
-                saveToCameraRoll
+                saveToCameraRoll, this.path
+        );
+    }
+
+    public @NonNull ImageConfig withPath(@Nullable final String path)
+    {
+        return new ImageConfig(
+                this.original, this.resized, this.maxWidth,
+                this.maxHeight, this.quality, this.rotation,
+                this.saveToCameraRoll, path
         );
     }
 
@@ -125,6 +137,7 @@ public class ImageConfig
             rotation = options.getInt("rotation");
         }
         boolean saveToCameraRoll = false;
+        String path = "";
         if (options.hasKey("storageOptions"))
         {
             final ReadableMap storageOptions = options.getMap("storageOptions");
@@ -132,8 +145,12 @@ public class ImageConfig
             {
                 saveToCameraRoll = storageOptions.getBoolean("cameraRoll");
             }
+            if (storageOptions.hasKey("path"))
+            {
+                path = storageOptions.getString("path");
+            }
         }
-        return new ImageConfig(this.original, this.resized, maxWidth, maxHeight, quality, rotation, saveToCameraRoll);
+        return new ImageConfig(this.original, this.resized, maxWidth, maxHeight, quality, rotation, saveToCameraRoll, path);
     }
 
     public boolean useOriginal(int initialWidth,

--- a/android/src/main/java/com/imagepicker/utils/MediaUtils.java
+++ b/android/src/main/java/com/imagepicker/utils/MediaUtils.java
@@ -46,10 +46,20 @@ public class MediaUtils
                 .append(".jpg")
                 .toString();
 
-        final File path = ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions") && !forceLocal
+        final File rootPath = ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions") && !forceLocal
                 ? Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
                 : reactContext.getExternalFilesDir(Environment.DIRECTORY_PICTURES);
 
+        String relativePath = "";
+        if (ReadableMapUtils.hasAndNotNullReadableMap(options, "storageOptions")) {
+            final ReadableMap storageOptions = options.getMap("storageOptions");
+            if (storageOptions.hasKey("path"))
+            {
+                relativePath = storageOptions.getString("path");
+            }
+        }
+
+        final File path = new File(rootPath, relativePath);
         File result = new File(path, filename);
 
         try

--- a/android/src/test/java/com/imagepicker/testing/media/ImageConfigTest.java
+++ b/android/src/test/java/com/imagepicker/testing/media/ImageConfigTest.java
@@ -25,7 +25,7 @@ public class ImageConfigTest
     @Test
     public void testOnImmutable()
     {
-        ImageConfig original = new ImageConfig(new File("original.txt"), new File("resized.txt"), 0, 0, 0, 0, false);
+        ImageConfig original = new ImageConfig(new File("original.txt"), new File("resized.txt"), 0, 0, 0, 0, false, null);
         ImageConfig updated = original.withOriginalFile(null);
 
         assertNotNull("Original has got original file", original.original);
@@ -60,25 +60,31 @@ public class ImageConfigTest
 
         assertEquals("Original saveToCameraRoll", false, original.saveToCameraRoll);
         assertEquals("Updated saveToCameraRoll", true, updated.saveToCameraRoll);
+
+        updated = original.withPath("test");
+
+        assertEquals("Original path", null, original.path);
+        assertEquals("Updated path", "test", updated.path);
     }
 
     @Test
     public void testParsingOptions()
     {
         WritableMap options = defaultOptions();
-        ImageConfig config = new ImageConfig(null, null, 0, 0, 0, 0, false);
+        ImageConfig config = new ImageConfig(null, null, 0, 0, 0, 0, false, null);
         config = config.updateFromOptions(options);
         assertEquals("maxWidth", 1000, config.maxWidth);
         assertEquals("maxHeight", 600, config.maxHeight);
         assertEquals("quality", 50, config.quality);
         assertEquals("rotation", 135, config.rotation);
         assertTrue("storageOptions.cameraRoll", config.saveToCameraRoll);
+        assertEquals("storageOptions.path", "test", config.path);
     }
 
     @Test
     public void testUseOriginal()
     {
-        ImageConfig config = new ImageConfig(null, null, 800, 600, 100, 90, false);
+        ImageConfig config = new ImageConfig(null, null, 800, 600, 100, 90, false, null);
 
         assertEquals("Image wont be resized", true, config.useOriginal(100, 100, 90));
         assertEquals("Image will be resized because of rotation", false, config.useOriginal(100, 100, 80));
@@ -92,7 +98,7 @@ public class ImageConfigTest
     @Test
     public void testGetActualFile()
     {
-        ImageConfig originalConfig = new ImageConfig(new File("original.txt"), null, 0, 0, 0, 0, false);
+        ImageConfig originalConfig = new ImageConfig(new File("original.txt"), null, 0, 0, 0, 0, false, null);
         ImageConfig resizedConfig = originalConfig.withResizedFile(new File("resized.txt"));
 
         assertEquals("For config which has got only original file", "original.txt", originalConfig.getActualFile().getName());
@@ -109,6 +115,7 @@ public class ImageConfigTest
 
         JavaOnlyMap storage = new JavaOnlyMap();
         storage.putBoolean("cameraRoll", true);
+        storage.putString("path", "test");
 
         options.putMap("storageOptions", storage);
 


### PR DESCRIPTION
## Motivation

- iOS supports saving images to a custom `path` using `storageOptions`. This feature is not yet available for Android.
- Providing `storageOptions.path` will now save the image to `Pictures/[path]` on Android.

## Test Plan

- A test case has been provided for setting the `path`.
- See image below of React Native project with `path` set to "Receipts".

<img width="626" alt="screen shot 2018-05-31 at 17 05 22" src="https://user-images.githubusercontent.com/7753956/40790295-d80aca78-64f4-11e8-95bd-a1e6681ae6ba.png">

