### PR TITLE
Add custom album support for iOS camera roll

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ storageOptions | OK | OK | If this key is provided, the image will be saved in y
 storageOptions.skipBackup | OK | - | If true, the photo will NOT be backed up to iCloud
 storageOptions.path | OK | - | If set, will save the image at `Documents/[path]/` rather than the root `Documents`
 storageOptions.cameraRoll | OK | OK | If true, the cropped photo will be saved to the iOS Camera Roll or Android DCIM folder.
+storageOptions.album | OK | - | If set, the photo will be added to a custom album in the iOS Photo Library (requires `cameraRoll`).
 storageOptions.waitUntilSaved | OK | - | If true, will delay the response callback until after the photo/video was saved to the Camera Roll. If the photo or video was just taken, then the file name and timestamp fields are only provided in the response object when this AND `cameraRoll` are both true.
 permissionDenied.title | - | OK | Title of explaining permissions dialog. By default `Permission denied`.
 permissionDenied.text | - | OK | Message of explaining permissions dialog. By default `To be able to take pictures with your camera and choose images from your library.`.


### PR DESCRIPTION
Add support for a custom album name when saving images to the Photo Library on iOS.

## Motivation

- On iOS, apps are able to assign images to a custom album when they are saved to the Photo Library.
- This adds a `storageOptions` parameter named `album` which takes a custom name.
- When `storageOptions.cameraRoll` is `true`, an album called `album` will be created if necessary and a copy of the image assigned to the album.
- This is distinct from `storageOptions.path` which applies to a custom folder in the app's `Documents` directory. This is not a user-facing path and might be something unsuitable for the Photo Library like "temp", "2018-05-01", etc.

## Test Plan

- With `storageOptions.cameraRoll: true` and `storageOptions.album` set to a string,
- After capturing an image using the camera on a real device,
- The image ought to appear in the Photo Library under "All Photos" and under the custom album name.
