### PR TITLE
Fix Android build error due to outdated gradle dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,11 +9,12 @@ def computeVersionName() {
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.+'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 
@@ -36,6 +37,7 @@ android {
 
 repositories {
     mavenCentral()
+    google()
     maven {
         url "$projectDir/../Example/node_modules/react-native/android"
     }
@@ -46,7 +48,7 @@ repositories {
 
 dependencies {
     compile "com.facebook.react:react-native:+"  // From node_modules
-    
+
     testCompile "junit:junit:4.10"
     testCompile "org.assertj:assertj-core:1.7.0"
     testCompile "org.robolectric:robolectric:3.3.2"


### PR DESCRIPTION
Fixes a build error caused by requiring Android Studio plugin `2.2.+` & not having `google()` dependency:

```
A problem occurred configuring project ':react-native-image-picker'.
> Could not resolve all files for configuration ':react-native-image-picker:classpath'.
   > Could not find any matches for com.android.tools.build:gradle:2.2.+ as no versions of com.android.tools.build:gradle are available.
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/build/gradle/maven-metadata.xml
         https://jcenter.bintray.com/com/android/tools/build/gradle/
     Required by:
         project :react-native-image-picker
```